### PR TITLE
Added support for user defined ~/.gitconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 
 # Ignore the scratch dir
 scratch/*
+
+# Support for custom /.gitconfig files
+/.gitconfig


### PR DESCRIPTION
Developers may create their own local .gitconfig files to modify git settings. For example, my local gitconfig specifies that I will use my davidneto92 GitHub account for commits.